### PR TITLE
Added support to run dev envrioment inside docker.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  frontend-dev:
+    image: "node:18"
+    user: node
+    working_dir: /home/node/CompSoc-Website
+    volumes:
+      - ./:/home/node/CompSoc-Website
+    expose:
+      - 3000
+    command: sh ./run_dev.sh
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,4 @@ services:
       - ./:/home/node/CompSoc-Website
     expose:
       - 3000
-    command: sh ./run_dev.sh
-
+    command: sh -c "npm install; npm run dev"

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+npm install
+
+npm run dev

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-npm install
-
-npm run dev


### PR DESCRIPTION
This commit adds two additional files to enable docker compose to be used for development.

The `run_dev.sh` file is used because docker does not work with `npm install && npm run dev`. It will just run `npm install` and then exit.

Due to the use of volumes, the docker container will live update as changes are made.