### PR TITLE
couple small features

### DIFF
--- a/components/Terminal/commands/info.ts
+++ b/components/Terminal/commands/info.ts
@@ -1,4 +1,4 @@
-import register, { CommandHandler, get_help, get_all_commands } from "./registry";
+import register, { CommandHandler, get_help, getAllCommands } from "./registry";
 import { whoami } from "./session";
 
 const echo: CommandHandler = (_, params) => {
@@ -47,7 +47,7 @@ const man: CommandHandler = (state, params) => {
     if (!helptext) return `No manual entry for ${params[0]}`;
     return helptext;
   }
-  const commandStrings = get_all_commands().join("\n");
+  const commandStrings = getAllCommands().join("\n");
   return `Help:\nThe following commands are available:\n${commandStrings}\nFor more information, run \`man PROGRAMNAME\``;
 };
 

--- a/components/Terminal/commands/info.ts
+++ b/components/Terminal/commands/info.ts
@@ -1,4 +1,4 @@
-import register, { CommandHandler, get_help, registry } from "./registry";
+import register, { CommandHandler, get_help, get_all_commands } from "./registry";
 import { whoami } from "./session";
 
 const echo: CommandHandler = (_, params) => {
@@ -47,7 +47,7 @@ const man: CommandHandler = (state, params) => {
     if (!helptext) return `No manual entry for ${params[0]}`;
     return helptext;
   }
-  const commandStrings = Object.keys(registry).join("\n");
+  const commandStrings = get_all_commands().join("\n");
   return `Help:\nThe following commands are available:\n${commandStrings}\nFor more information, run \`man PROGRAMNAME\``;
 };
 

--- a/components/Terminal/commands/registry.ts
+++ b/components/Terminal/commands/registry.ts
@@ -21,6 +21,6 @@ export function get_help(name: string) {
   return registry[name]?.help
 }
 
-export function get_all_commands() {
+export function getAllCommands() {
   return Object.keys(registry)
 }

--- a/components/Terminal/commands/registry.ts
+++ b/components/Terminal/commands/registry.ts
@@ -20,3 +20,7 @@ export function get_command(name: string) {
 export function get_help(name: string) {
   return registry[name]?.help
 }
+
+export function get_all_commands() {
+  return Object.keys(registry)
+}

--- a/components/Terminal/index.vue
+++ b/components/Terminal/index.vue
@@ -129,10 +129,9 @@ function clearScreen() {
 
 register({
   name: "clear",
-  fn: (state, params) => {
-    // HACK
+  fn: (state, _) => {
     // we can't clear it immediately, because the 'clear' command will be drawn on screen AFTER this has run, due to the way the command systems works
-    setTimeout(clearScreen, 50);
+    nextTick(clearScreen)
     return "";
   },
   help: "Clear the screen completely",

--- a/components/Terminal/index.vue
+++ b/components/Terminal/index.vue
@@ -9,7 +9,7 @@ import type { State } from "./commands/registry";
 import get_command from "./commands";
 import { cwd } from "./commands/filesystem";
 import register from "./commands/registry";
-import { get_all_commands } from "./commands/registry";
+import { getAllCommands } from "./commands/registry";
 
 interface HistoryItem {
   input: string;
@@ -47,7 +47,7 @@ function handleInput(event: KeyboardEvent) {
   event.preventDefault();
 
   if (key === "Tab") {
-    const cmds = get_all_commands();
+    const cmds = getAllCommands();
     const [partialCmd, ...args] = activeLineBuffer.value.trim().split(" ");
 
     if (!partialCmd || args.length > 0) {


### PR DESCRIPTION
- make it possible to clear the screen and preserve command history
- use a cleaner solution using `nextTick` for screen clearing, opposed to `setTimeout`
- have basic tab autocomplete
- make the terminal scrollable instead of it expanding in size, with autoscroll to the last command output
